### PR TITLE
Address QA issues. (PT-186719376)

### DIFF
--- a/src/components/date-range/calendar-header.tsx
+++ b/src/components/date-range/calendar-header.tsx
@@ -3,6 +3,7 @@ import { useStateContext } from "../../hooks/use-state";
 import { IState } from "../../types";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import dayjs from "dayjs";
 
 import "./calendar-header.scss";
 
@@ -11,8 +12,8 @@ interface ICalendarHeader {
   handleSelectCalendar: () => void;
 }
 
-export const CalendarHeader = ({calendarType, handleSelectCalendar}: ICalendarHeader) =>
-  {  const { state, setState } = useStateContext();
+export const CalendarHeader = ({calendarType, handleSelectCalendar}: ICalendarHeader) => {
+  const { state, setState } = useStateContext();
   const {startDate, endDate} = state;
 
   if (!startDate || !endDate) {
@@ -30,9 +31,12 @@ export const CalendarHeader = ({calendarType, handleSelectCalendar}: ICalendarHe
 
   const handleSetDate = (date: Date) => {
     const key = calendarType === "start" ? "startDate" : "endDate";
-    setState((draft: IState) => {
-      draft[key] = date;
-    });
+    const isValidDate = calendarType === "start" ? dayjs(date).isBefore(endDate) : dayjs(date).isAfter(startDate);
+    if (isValidDate) {
+      setState((draft: IState) => {
+        draft[key] = date;
+      });
+    }
   };
 
   const handleNext = () => {

--- a/src/components/date-range/calendar.tsx
+++ b/src/components/date-range/calendar.tsx
@@ -14,7 +14,7 @@ interface ICalendar {
 
 export const Calendar = ({calendarType, handleSelectCalendar}: ICalendar) => {
   const { state, setState } = useStateContext();
-  const {startDate, endDate} = state;
+  const { startDate, endDate } = state;
 
   if (!startDate || !endDate) {
     return null;
@@ -28,9 +28,13 @@ export const Calendar = ({calendarType, handleSelectCalendar}: ICalendar) => {
 
   const handleSetDate = (date: Date) => {
     const key = calendarType === "start" ? "startDate" : "endDate";
-    setState((draft: IState) => {
-      draft[key] = date;
-    });
+    const isValidDate = calendarType === "start" ? dayjs(date).isBefore(endDate) : dayjs(date).isAfter(startDate);
+    if (isValidDate) {
+      setState((draft: IState) => {
+        draft[key] = date;
+        draft.didUserSelectDate = true;
+      });
+    }
   };
 
   const handleDateClick = (e: React.MouseEvent<HTMLTableCellElement>) => {

--- a/src/components/date-range/calendars.scss
+++ b/src/components/date-range/calendars.scss
@@ -17,6 +17,7 @@
     height: 224px;
     background-color: white;
     border-radius: 8px;
+    z-index: 10;
     .calendar-column {
       width: 171px;
       height: 224px;
@@ -37,6 +38,7 @@
     padding: 6px;
     align-items: center;
     background-color: white;
+    border-radius: 0px 0px 8px 8px;
     .station-information {
       display: flex;
       flex-direction: column;

--- a/src/components/date-range/date-range.tsx
+++ b/src/components/date-range/date-range.tsx
@@ -137,7 +137,7 @@ export const DateRange = () => {
                 <div className="warning-exit" onClick={() => setShowWarningModal(false)}><ExitIcon/></div>
               </div>
               <div className="warning-body">
-                Your current range is likely to return too many results, which
+                Your current date range is likely to return too many results, which
                 may affect application performance.
               </div>
               <div className="warning-footer">

--- a/src/components/date-range/date-range.tsx
+++ b/src/components/date-range/date-range.tsx
@@ -11,7 +11,7 @@ import "./date-range.scss";
 
 export const DateRange = () => {
   const { state, setState } = useStateContext();
-  const { frequency, startDate, endDate } = state;
+  const { frequency, startDate, endDate, didUserSelectDate } = state;
   const [selectedCalendar, setSelectedCalendar] = useState<string>(); // "start" | "end"
   const [showCalendars, setShowCalendars] = useState(false);
   const [showWarningIcon, setShowWarningIcon] = useState(false);
@@ -39,6 +39,12 @@ export const DateRange = () => {
     setState(draft => {
       draft.frequency = freq;
     });
+
+    // if user has not clicked on a calendar date, set to the default date range
+    if (!didUserSelectDate && startDate && endDate) {
+      handleSetStartDate(constants.defaultDates[freq].start);
+      handleSetEndDate(constants.defaultDates[freq].end);
+    }
   };
 
   const handleSetStartDate = (date: Date) => {

--- a/src/components/date-range/date-selector.scss
+++ b/src/components/date-range/date-selector.scss
@@ -22,6 +22,7 @@
   }
   &.selected {
     background-color: $teal-light-25;
+    font-weight: 600;
   }
   &.placeholder {
     color: $placeholder-gray;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,7 +29,7 @@ export const constants = {
     },
     "monthly": {
       start: today.subtract(10, "year").toDate(),
-      end: today.toDate()
+      end: today.subtract(1, "day").toDate()
     }
   },
   defaultCoords: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,8 +149,6 @@ export const DefaultState: IState = {
                 daily: {attrs: dailyMonthlyAttrMap, filters: []},
                 monthly: {attrs: [], filters: []}},
   units: "standard",
-  attributes: [],
-  filters: [],
   didUserSelectDate: false,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,6 +131,7 @@ export interface IState {
   attributes: string[];
   filters: IFilter[];
   showModal?: "info" | "data-return-warning";
+  didUserSelectDate: boolean;
 }
 
 export const DefaultState: IState = {
@@ -138,6 +139,7 @@ export const DefaultState: IState = {
   units: "standard",
   attributes: [],
   filters: [],
+  didUserSelectDate: false,
 };
 
 export const kStationsDatasetName = "US-Weather-Stations";

--- a/src/utils/codapConnect.ts
+++ b/src/utils/codapConnect.ts
@@ -1,4 +1,4 @@
-import { IResult, codapInterface, createDataContext, createItems, createNewCollection } from "@concord-consortium/codap-plugin-api";
+import { codapInterface, createDataContext, createItems, createNewCollection } from "@concord-consortium/codap-plugin-api";
 import { IWeatherStation, kStationsCollectionName, kStationsDatasetName, kWeatherStationCollectionAttrs } from "../types";
 
 export const createStationsDataset = async(stations: IWeatherStation[]) => {


### PR DESCRIPTION
This PR fixes the following issues:
    - When the monthly data frequency option is selected, the end date doesn't autofill to yesterday's date. The end date autofills with the current date
    - The active field is highlighted but the date field is not semi-bold.
    - As per the acceptance criteria, "Date range from station title stripped and displayed below the calendars" is not implemented. Could you please confirm whether this will be implemented as part of this ticket or a separate ticket?
    - As per the acceptance criteria, "Changing the frequency option changes the attributes shown" is not implemented. Need to refresh the page and make the selection after the page loads to see the data range changes based on the frequency selection. 
    - Able to set the end date as less than the start date. 
    - The calendar date workspace overlaps with the Units