### PR TITLE
186752847 attribute selection defaults

### DIFF
--- a/src/components/attribute-selector.tsx
+++ b/src/components/attribute-selector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import classnames from "classnames";
 import { useStateContext } from "../hooks/use-state";
 import { dailyMonthlyAttrMap, hourlyAttrMap } from "../types";
@@ -14,6 +14,14 @@ export const AttributesSelector = () => {
   const attributeList = selectedFrequency === "hourly" ? hourlyAttrMap : dailyMonthlyAttrMap;
   const attributeNamesList = selectedFrequency === "hourly" ? hourlyAttributeNames : dailyMonthlyAttributeNames;
   const selectedAttrsAndFiltersForFrequency = frequencies[selectedFrequency];
+
+  useEffect(() => {
+    if (frequencies[selectedFrequency].attrs.length === attributeList.length) {
+      setAllSelected(true);
+    } else {
+      setAllSelected(false);
+    }
+  }, [attributeList.length, frequencies, selectedFrequency]);
 
   const handleUnitsClicked = () => {
     setState(draft => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -148,9 +148,9 @@ export const hourlyAttrMap: AttrType[] = [
 
 export const DefaultState: IState = {
   selectedFrequency: "daily",
-  frequencies: {hourly: {attrs: [], filters: []},
+  frequencies: {hourly: {attrs: hourlyAttrMap, filters: []},
                 daily: {attrs: dailyMonthlyAttrMap, filters: []},
-                monthly: {attrs: [], filters: []}},
+                monthly: {attrs: dailyMonthlyAttrMap, filters: []}},
   units: "standard",
   didUserSelectDate: false,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export const dailyMonthlyAttrMap: AttrType[] = [
   {name: "Average temperature", abbr: "tAvg", unit: unitMap.temperature},
   {name: "Precipitation", abbr: "precip", unit: unitMap.precipitation},
   {name: "Snowfall", abbr: "snow", unit: unitMap.precipitation},
-  {name: "Average windspeed", abbr: "avgWind", unit: unitMap.speed}
+  {name: "Average wind speed", abbr: "avgWind", unit: unitMap.speed}
 ];
 
 export const hourlyAttrMap: AttrType[] = [


### PR DESCRIPTION
Fixes bugs in attribute selection:
- Fix: When compared to Zeplin, space is missing between the text wind speed in the Average wind speed button.
- Fix: After the initial load, switch to hourly/monthly, unselect the All attribute button then switch to other periods and notice that the All button is unselected in other periods too.
- Fix: As per acceptance criteria 4th point, "By default, all attributes are selected" but currently, no attributes are selected by default. Works fine for daily period selection but still, for hourly/monthly, no attributes are selected by default. All button is selected but no table is displayed below attributes. Check that "After the initial load, switch to the hourly/monthly period, select any of the attribute buttons and notice duplicate entries are displayed in the table" is fixed.