### PR TITLE
186752905 filter function fixes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -21,7 +21,7 @@ const kPluginName = "NOAA Weather Station Data";
 const kVersion = "0014";
 const kInitialDimensions = {
   width: 360,
-  height: 495
+  height: 650
 };
 
 export const App = () => {

--- a/src/components/attribute-filter.scss
+++ b/src/components/attribute-filter.scss
@@ -205,21 +205,24 @@ table tr:nth-child(odd) {
   }
 
   .filter-operator-selection-container {
-    width: 148px;
-    height: 190px;
-    padding: 9px;
+    width: 155px;
+    max-height: 190px;
+    padding: 9px 12px 5px 9px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
     background-color: #fff;
     position: relative;
     right: -22px;
     top: -50px;
     box-sizing: border-box;
-    overflow: hidden;
+    overflow-y: auto;
+    overflow-x: hidden;
 
     .operator-selection {
       border: none;
       width: 100%;
+      height: 176px;
       outline: none;
+      box-sizing: border-box;
 
       option {
         font-family: "Montserrat", sans-serif;

--- a/src/components/attribute-filter.scss
+++ b/src/components/attribute-filter.scss
@@ -214,6 +214,7 @@ table tr:nth-child(odd) {
     right: -22px;
     top: -50px;
     box-sizing: border-box;
+    overflow: hidden;
 
     .operator-selection {
       border: none;
@@ -226,6 +227,8 @@ table tr:nth-child(odd) {
         font-weight: 500;
         color: #000;
         padding: 2px 0;
+        height: 12px;
+
         &:hover {
           background-color: $teal-medium;
         }

--- a/src/components/attribute-filter.scss
+++ b/src/components/attribute-filter.scss
@@ -208,13 +208,13 @@ table tr:nth-child(even) {
   }
 
   .filter-operator-selection-container {
-    width: 155px;
+    width: 165px;
     max-height: 190px;
     padding: 9px 12px 5px 9px;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
     background-color: #fff;
     position: relative;
-    right: -22px;
+    right: -5px;
     top: -50px;
     box-sizing: border-box;
     overflow-y: auto;

--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -118,6 +118,7 @@ export const AttributeFilter = () => {
         {(attributeToFilter && showFilterModal) &&
               <FilterModal attr={attributeToFilter} setShowFilterModal={setShowFilterModal} position={filterModalPosition}
                             setFilterModalPosition={setFilterModalPosition} targetFilterBottom={targetFilterBottom}
+                            key={attributeToFilter.name}
               />}
       </div>
     );

--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -196,7 +196,6 @@ const FilterModal = ({attr, position, targetFilterBottom, setShowFilterModal, se
   // Change filter-operator-selection-container height if window is shorter than dropdown
   useEffect(() => {
     if (showOperatorSelectionModal) {
-      console.log("dropdownBottom && dropdownBottom > windowHeight", dropdownBottom, windowHeight, dropdownBottom && dropdownBottom > windowHeight);
       if (dropdownBottom && dropdownBottom > windowHeight) {
         const cutOffAmount = dropdownBottom - windowHeight;
         setOperatorSelectionListHeight({height: 190 - cutOffAmount - 3});

--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -237,7 +237,7 @@ useEffect(() => {
     // key attribute forces inputs to rerender when operator changes
     if (operator === "between") {
       return (
-        <div className="between-inputs-wrapper" key="between">
+        <div className="between-inputs-wrapper" key={`${operator}-${units}`}>
           <input ref={filterLowerValueInputElRef} className="filter-value between-low-value"
             defaultValue={`${lowerVal} ${currentAttr?.unit[units]}`}>
           </input>
@@ -250,9 +250,9 @@ useEffect(() => {
     } else if (operator === "aboveMean" || operator === "belowMean") {
       return null;
     } else if (operator === "top" || operator === "bottom") {
-      return <input ref={filterValueTopBottomInputElRef} key={operator} className="filter-value" defaultValue={`${currentFilterValue || "100"}`}></input>;
+      return <input ref={filterValueTopBottomInputElRef} key={`${operator}-${units}`} className="filter-value" defaultValue={`${currentFilterValue || "100"}`}></input>;
     } else {
-      return <input ref={filterValueInputElRef} key={operator} className="filter-value" defaultValue={`${currentFilterValue} ${currentAttr?.unit[units]}`}></input>;
+      return <input ref={filterValueInputElRef} key={`${operator}-${units}`} className="filter-value" defaultValue={`${currentFilterValue} ${currentAttr?.unit[units]}`}></input>;
     }
   };
 

--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -88,7 +88,7 @@ export const AttributeFilter = () => {
                   : filterAboveOrBelowMean
                       ? `${operatorTextMap[attrFilter.operator]}`
                       : attrFilter.operator === "between"
-                          ? `${attrFilter.lowerValue} - ${attrFilter.upperValue} ${attr.unit[units]}`
+                          ? `${attrFilter.lowerValue} ${attr.unit[units]} - ${attrFilter.upperValue} ${attr.unit[units]}`
                           : attrFilter.operator === "top" || attrFilter.operator === "bottom"
                             ? `${operatorTextMap[attrFilter.operator]} ${attrFilter.value}`
                             :`${operatorSymbolMap[attrFilter.operator]} ${attrFilter.value} ${attr.unit[units]}`;
@@ -268,13 +268,13 @@ useEffect(() => {
   return (
     <div className={classnames("filter-modal", {"wide": wideModal})} style={position}>
       <div className="filter-wrapper">
-        <div className="filter-operator-wrapper">
-          <div className="filter-operator" onClick={handleChangeFilterOperator}>
+        <div className="filter-operator-wrapper" onClick={handleChangeFilterOperator}>
+          <div className="filter-operator">
             {operatorTextMap[operator] || "equals"}
           </div>
           <EditIcon />
         </div>
-        {!noValueFilter && renderFilterInputs() }
+        {renderFilterInputs()}
         {(operator === "top" || operator === "bottom") && <span>{` results`}</span>}
       </div>
       <div className="filter-modal-footer">

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface AttrType {
 export type TOperators = "equals" | "doesNotEqual" | "greaterThan" | "greaterThanOrEqualTo" | "lessThan"
                             | "lessThanOrEqualTo" | "between" | "top" | "bottom" | "aboveMean" | "belowMean";
 
-export const operatorTextMap = {equals: "equals", doesNotEqual: "does not equal", greaterThan: "greater than", greaterThanOrEqualTo: "great than or equal to",
+export const operatorTextMap = {equals: "equals", doesNotEqual: "does not equal", greaterThan: "greater than", greaterThanOrEqualTo: "greater than or equal to",
 lessThan: "less than", lessThanOrEqualTo: "less than or equal to", between: "between", top: "top", bottom: "bottom",
 aboveMean: "above mean", belowMean: "below mean"};
 export const operatorSymbolMap = {equals: "=", doesNotEqual: "≠", greaterThan: ">", greaterThanOrEqualTo: ">=", lessThan: "<", lessThanOrEqualTo: "<="};

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,8 @@ export interface AttrType {
 export type TOperators = "equals" | "doesNotEqual" | "greaterThan" | "greaterThanOrEqualTo" | "lessThan"
                             | "lessThanOrEqualTo" | "between" | "top" | "bottom" | "aboveMean" | "belowMean";
 
-export const operatorTextMap = {equals: "equals", doesNotEqual: "does not equal", greaterThan: "greater than", greaterThanOrEqualTo: "greater than or equal to",
-lessThan: "less than", lessThanOrEqualTo: "less than or equal to", between: "between", top: "top", bottom: "bottom",
+export const operatorTextMap = {equals: "equals", doesNotEqual: "does not equal", greaterThan: "is greater than", greaterThanOrEqualTo: "is greater than or equal to",
+lessThan: "is less than", lessThanOrEqualTo: "is less than or equal to", between: "between", top: "top", bottom: "bottom",
 aboveMean: "above mean", belowMean: "below mean"};
 export const operatorSymbolMap = {equals: "=", doesNotEqual: "≠", greaterThan: ">", greaterThanOrEqualTo: ">=", lessThan: "<", lessThanOrEqualTo: "<="};
 


### PR DESCRIPTION
Fixes bugs found by QA:
- Changing attribute selected to filter does not update the info in the filter modal
- Expand click handler to include the Edit Icon
- Made operator list a little wider to accomodate the scroll bar
- Fixed the "greater than or equal to" text
- Added unit to the lower value for the between operator 
- Fix bug where input value does not show when `above mean` or `below mean` were previously selected
- Fixed bug where if user changes unit type selection, the filter modal didn't update to the new unit type
- Changed the default height of the plugin to accomodate the lowest filter modal position by default.
- Made operator selection list scrollable if the bottom of the list is below the window height.