### PR TITLE
Fixes the double input value when switching from between operator to …

### DIFF
--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -289,9 +289,13 @@ const FilterModal = ({attr, position, targetFilterBottom, setShowFilterModal, se
     } else if (operator === "aboveMean" || operator === "belowMean") {
       return null;
     } else if (operator === "top" || operator === "bottom") {
-      return <input ref={filterValueTopBottomInputElRef} key={`${operator}-${units}`} className="filter-value" defaultValue={`${currentFilterValue || "100"}`}></input>;
+      return  <input ref={filterValueTopBottomInputElRef} key={`${operator}-${units}`} className="filter-value"
+                    defaultValue={`${Array.isArray(currentFilterValue) ? currentFilterValue[0] : "100"}`}>
+              </input>;
     } else {
-      return <input ref={filterValueInputElRef} key={`${operator}-${units}`} className="filter-value" defaultValue={`${currentFilterValue} ${currentAttr?.unit[units]}`}></input>;
+      return  <input ref={filterValueInputElRef} key={`${operator}-${units}`} className="filter-value"
+                defaultValue={`${Array.isArray(currentFilterValue) ? currentFilterValue[0] : "100"} ${currentAttr?.unit[units]}`}>
+              </input>;
     }
   };
 


### PR DESCRIPTION
…any single value operator

We were using the `currentFilterValue` stored in state for the variable. When user enters values for the `between` operator, we store those values into an array. When user switches to a single value operator like `equals`, it shows the `currentFilterValue` array as the value in the input field.
This checks to see if `currentFilterValue` is an array, and if it is, we will just use the first or lower input value of the array.