### PR TITLE
Fixes filter cell height styling when the row height changes

### DIFF
--- a/src/components/attribute-filter.scss
+++ b/src/components/attribute-filter.scss
@@ -49,7 +49,6 @@ $filter-green: #2dbe5e;
     font-weight: 500;
     color: #000;
     text-align: left;
-    padding-left: 5px;
 
     td.filter-units {
       text-align: center;
@@ -59,15 +58,14 @@ $filter-green: #2dbe5e;
     }
 
     td.filter-filter {
-      display: flex;
-      align-items: center;
-      justify-content: flex-end;
+      display: table-cell;
       text-align: right;
       background-color: $teal-light-25;
       color: #177991;
       font-size: 10px;
       box-sizing: border-box;
       cursor: pointer;
+      height: 100%;
 
       &.filtering {
         background-color: $filter-background-green-25;
@@ -87,6 +85,8 @@ $filter-green: #2dbe5e;
         display: flex;
         flex-direction: row;
         align-items: center;
+        justify-content: flex-end;
+        height: 100%;
 
         .edit-icon {
           margin: 0 3px 0 7px;


### PR DESCRIPTION
When we add a filter to Barometric Pressure, the row grows taller with the narrower Attributes column. But the filter cell was ignoring the height change.
<img width="380" alt="image" src="https://github.com/concord-consortium/noaa-codap-plugin/assets/7716653/bfdfef38-0f84-44a3-886c-0993e7aef3c8">
This fixes it so that styling goes to entire filter cell:
<img width="348" alt="image" src="https://github.com/concord-consortium/noaa-codap-plugin/assets/7716653/7e6980b0-0908-4c47-a574-80fdc8b26ad2">
