### PR TITLE
Close filter modal if user changes frequency

### DIFF
--- a/src/components/attribute-filter.tsx
+++ b/src/components/attribute-filter.tsx
@@ -50,6 +50,11 @@ export const AttributeFilter = () => {
       setHasFilter(anyFilters);
   },[frequencies, selectedAttrMap, selectedFrequency]);
 
+  //close filter modal if user changes selectedFrequency
+  useEffect(()=>{
+    setShowFilterModal(false);
+  },[selectedFrequency]);
+
   const handleFilterClick = (e: React.MouseEvent<HTMLDivElement>, index: number) => {
     const rect = e.currentTarget.getBoundingClientRect();
     const top = rect.bottom + window.scrollY;


### PR DESCRIPTION
Currently, the filter modal does not recognize click away by design so that users can click on other filters without having to close the modal. But when we change frequency, the attributes may change and the filter modal loses track of which attribute it was attached to. 
So we make it so that if the user changes frequency, the filter modal should close.