### PR TITLE
[186962573] - Map opens after user closes it and selects a new location

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -102,10 +102,11 @@ export const App = () => {
 
     const createMapListener = (listenerRes: ClientNotification) => {
       const { values } = listenerRes;
-      if (values.operation === "delete" && values.type === "DG.MapView" && values.name === "US Weather Stations") {
+      if (values.operation === "delete" && values.type === "DG.MapView" && values.name === "US-Weather-Stations") {
         setState((draft) => {
           draft.zoomMap = false;
           draft.isMapOpen = false;
+          draft.didUserSelectStationFromMap = false;
         });
       }
     };

--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -225,8 +225,10 @@ export const LocationPicker = () => {
         placeNameSelected(locationPossibilities[selectedLocIdx]);
         setState(draft=>{
           draft.location = locationPossibilities[selectedLocIdx];
-          draft.zoomMap = true;
           draft.didUserSelectStationFromMap = false;
+          if (state.isMapOpen) {
+            draft.zoomMap = true;
+          }
         });
       }
     }


### PR DESCRIPTION
Fixes map opening when user selects a new location after map has been closed. We were passing the wrong name to the listener and so flag that tells plugin that map is closed never got toggled to false.