### PR TITLE
186972298 repopulate location selection list

### DIFF
--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -55,6 +55,7 @@ export const LocationPicker = () => {
       // Unbind the event listener on clean up
       document.removeEventListener("mousedown", handleClickOutside);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -299,8 +300,10 @@ export const LocationPicker = () => {
 
   const handleLocationInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCandidateLocation(e.target.value);
-    getLocationList();
-    setShowSelectionList(true);
+    if (e.target.value.length > 3) {
+      getLocationList();
+      setShowSelectionList(true);
+    }
   };
 
   const handleLocationInputClick = () => {

--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -267,9 +267,7 @@ export const LocationPicker = () => {
 
   const handleLocationInputClick = () => {
     setIsEditing(true);
-    console.log("candidateLocation", candidateLocation, candidateLocation.length);
     if (candidateLocation.length >= 3) {
-      console.log("in handleLocationInputClick if");
       getLocationList();
     }
   };

--- a/src/components/location-picker.tsx
+++ b/src/components/location-picker.tsx
@@ -5,6 +5,7 @@ import { geonamesUser, kOffsetMap, timezoneServiceURL } from "../constants";
 import { useStateContext } from "../hooks/use-state";
 import { IPlace, IStation } from "../types";
 import { convertDistanceToStandard, findNearestActiveStations } from "../utils/getWeatherStations";
+import { selectStations } from "../utils/codapHelpers";
 import OpenMapIcon from "../assets/images/icon-map.svg";
 import EditIcon from "../assets/images/icon-edit.svg";
 import LocationIcon from "../assets/images/icon-location.svg";
@@ -46,6 +47,15 @@ export const LocationPicker = () => {
           setShowSelectionList(false);
           setIsEditing(false);
         }
+        if (locationInputEl.current && !locationInputEl.current.contains(event.target as Node) && !locationSelectionListElRef.current?.contains(event.target as Node) && !locationDivRef.current?.contains(event.target as Node)) {
+          setIsEditing(false);
+          setShowSelectionList(false);
+          setShowMapButton(false);
+          setState((draft) => {
+            draft.location = undefined;
+            draft.zoomMap = false;
+          });
+        }
       }
     }
 
@@ -77,6 +87,12 @@ export const LocationPicker = () => {
     }
   }, [location]);
 
+  useEffect(()=> {
+    if (isEditing && locationPossibilities.length > 0) {
+      setShowSelectionList(true);
+    }
+  }, [isEditing, locationPossibilities]);
+
   useEffect(() => {
     const _startDate = startDate ? startDate : new Date( -5364662060); // 1/1/1750
     const _endDate = endDate ? endDate : new Date(Date.now());
@@ -85,7 +101,6 @@ export const LocationPicker = () => {
         .then((stationList: IStation[]) => {
           if (stationList) {
             setStationPossibilities(stationList);
-            (isEditing && stationList.length > 0) && setShowSelectionList(true);
           }
           setState((draft) => {
             draft.weatherStation = stationList[0].station;
@@ -131,22 +146,29 @@ export const LocationPicker = () => {
     }
   },[showStationSelectionList]);
 
+  // Location selection functions
   const getLocationList = () => {
     if (locationInputEl.current) {
       autoComplete(locationInputEl.current)
         .then ((placeList: IPlace[] | undefined) => {
-                  if (placeList) {
-                    setLocationPossibilities(placeList);
-                    (isEditing && placeList.length > 0) && setShowSelectionList(true);
-                  }
+                if (placeList) {
+                  setLocationPossibilities(placeList);
+                }
               });
     }
   };
+
+  useEffect(() => {
+    if (isEditing) {
+      getLocationList();
+    }
+  }, [isEditing]);
 
   const placeNameSelected = (place: IPlace | undefined) => {
     setState(draft => {
       draft.location = place;
       draft.didUserSelectStationFromMap = false;
+      draft.zoomMap = true;
     });
     setCandidateLocation(place?.name || "");
     setShowSelectionList(false);
@@ -154,16 +176,6 @@ export const LocationPicker = () => {
     setShowMapButton(true);
     setLocationPossibilities([]);
     setHoveredIndex(null);
-    setArrowedIndex(-1);
-  };
-
-  const stationSelected = (station: IWeatherStation | undefined) => {
-    setState(draft => {
-      draft.weatherStation = station;
-      draft.didUserSelectStationFromMap = false;
-    });
-    setShowStationSelectionList(false);
-    setStationHoveredIndex(null);
     setArrowedIndex(-1);
   };
 
@@ -208,10 +220,6 @@ export const LocationPicker = () => {
     setHoveredIndex(index);
   };
 
-  const handleStationHover = (index: number | null) => {
-    setStationHoveredIndex(index);
-  };
-
   const handleLocationInputBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const target = e.target;
     if (target.value !== "") {
@@ -220,6 +228,7 @@ export const LocationPicker = () => {
     } else {
       setIsEditing(false);
       setCandidateLocation(location?.name || "");
+      selectStations([]);
     }
   };
 
@@ -229,25 +238,41 @@ export const LocationPicker = () => {
       const selectedLocIdx = parseInt(target.dataset.ix, 10);
       if (selectedLocIdx >= 0) {
         placeNameSelected(locationPossibilities[selectedLocIdx]);
-        setState(draft=>{
-          draft.location = locationPossibilities[selectedLocIdx];
-          draft.didUserSelectStationFromMap = false;
-          if (state.isMapOpen) {
-            draft.zoomMap = true;
-          }
-        });
       }
     }
   };
 
-  const handlePlaceNameSelectionKeyDown = (e: React.KeyboardEvent<HTMLLIElement>, index: number) => {
-    if (e.key === "Enter") {
-      placeNameSelected(locationPossibilities[index-1]);
-      setState(draft => {
-        draft.zoomMap = true;
+  const handleFindCurrentLocation = async() => {
+    navigator.geolocation.getCurrentPosition((position: GeolocationPosition) => {
+      const lat = position.coords.latitude;
+      const long = position.coords.longitude;
+      geoLocSearch(lat, long).then((currPosName) => {
+        setState(draft => {
+          draft.location = {name: currPosName, latitude: lat, longitude: long};
+          draft.didUserSelectStationFromMap = false;
+        });
+        placeNameSelected({name: currPosName, latitude: lat, longitude: long});
       });
+    });
+  };
+
+  const handleLocationInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCandidateLocation(e.target.value);
+    if (e.target.value.length >= 3) {
+      getLocationList();
     }
   };
+
+  const handleLocationInputClick = () => {
+    setIsEditing(true);
+    console.log("candidateLocation", candidateLocation, candidateLocation.length);
+    if (candidateLocation.length >= 3) {
+      console.log("in handleLocationInputClick if");
+      getLocationList();
+    }
+  };
+
+  // Station selection functions
 
   const handleStationSelection = (ev: React.MouseEvent<HTMLLIElement>) => {
     const target = ev.currentTarget;
@@ -284,30 +309,18 @@ export const LocationPicker = () => {
     }
   };
 
-  const handleFindCurrentLocation = async() => {
-    navigator.geolocation.getCurrentPosition((position: GeolocationPosition) => {
-      const lat = position.coords.latitude;
-      const long = position.coords.longitude;
-      geoLocSearch(lat, long).then((currPosName) => {
-        setState(draft => {
-          draft.location = {name: currPosName, latitude: lat, longitude: long};
-          draft.didUserSelectStationFromMap = false;
-        });
-        placeNameSelected({name: currPosName, latitude: lat, longitude: long});
-      });
+  const stationSelected = (station: IWeatherStation | undefined) => {
+    setState(draft => {
+      draft.weatherStation = station;
+      draft.didUserSelectStationFromMap = false;
     });
+    setShowStationSelectionList(false);
+    setStationHoveredIndex(null);
+    setArrowedIndex(-1);
   };
 
-  const handleLocationInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCandidateLocation(e.target.value);
-    if (e.target.value.length > 3) {
-      getLocationList();
-      setShowSelectionList(true);
-    }
-  };
-
-  const handleLocationInputClick = () => {
-    setIsEditing(true);
+  const handleStationHover = (index: number | null) => {
+    setStationHoveredIndex(index);
   };
 
   const handleOpenMap = () => {
@@ -375,8 +388,8 @@ export const LocationPicker = () => {
               className={classnames("location-selection-list", {"show": showSelectionList, "short" : showMapButton})}
               onFocus={() => setHoveredIndex(null)}>
               <li className={classnames("current-location-wrapper", {"geoname-candidate": hoveredIndex === -1})}
-                  tabIndex={1} onClick={handleFindCurrentLocation} onMouseOver={() => handleLocationHover(null)}
-                  onKeyDown={(e)=>handlePlaceNameSelectionKeyDown(e, 0)}>
+                  tabIndex={1} onClick={handleFindCurrentLocation} onMouseOver={() => handleLocationHover(null)}>
+                  {/* onKeyDown={(e)=>handlePlaceNameSelectionKeyDown(e, 0)}> */}
                 <CurrentLocationIcon className="current-location-icon"/>
                 <span className="current-location">Use current location</span>
               </li>
@@ -385,7 +398,8 @@ export const LocationPicker = () => {
                     return (
                       <li  key={`${loc}-${idx}`} data-ix={`${idx}`} tabIndex={1}
                             className={classnames("location-selector-option", {"geoname-candidate": hoveredIndex === idx})}
-                            onMouseOver={()=>handleLocationHover(idx)} onClick={(e)=>handlePlaceNameSelection(e)} onKeyDown={(e)=>handlePlaceNameSelectionKeyDown(e,idx)}>
+                            onMouseOver={()=>handleLocationHover(idx)} onClick={(e)=>handlePlaceNameSelection(e)}>
+                               {/* onKeyDown={(e)=>handlePlaceNameSelectionKeyDown(e,idx)}> */}
                         <span className="location-name">{loc.name}</span>
                       </li>
                     );


### PR DESCRIPTION
Consolidates location selection code.

When user deletes selected location and clicks away, we now store the deleted state instead of restoring the previously selected location. This also deselects the weather station from the map if the map is open.

Fixes a bug when user selects a location using the keyboard, then clicks the location input field, we were showing a blank location selection list. Now the list is populated based on the current value of the input field.