### PR TITLE
updates no data received message

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -159,7 +159,24 @@ export const App = () => {
     const maxDate = endDate || new Date(Date.now());
     guaranteeGlobal(globalMinDate, Number(minDate)/1000);
     guaranteeGlobal(globalMaxDate, Number(maxDate)/1000);
-  }, [endDate, startDate, weatherStations]);
+    if (weatherStation && (!startDate || !endDate)) {
+      setStatus({
+        status: "error",
+        message: "Select a date range",
+        icon: <WarningIcon/>
+      });
+    }
+    // if the start date of the weather station is after the user's requested end date, then the station is inactive
+    const stationMinDate = new Date(weatherStation?.mindate || globalMinDate);
+    const stationNotActiveYet = stationMinDate > maxDate;
+    if (stationNotActiveYet) {
+      setStatus({
+        status: "station-error",
+        message: "Station was inactive for date range",
+        icon: <WarningIcon/>
+      });
+    }
+  }, [endDate, startDate, weatherStations, weatherStation]);
 
   const stationSelectionHandler = async(req: any) =>{
     if (req.values.operation === "selectCases") {
@@ -237,7 +254,7 @@ export const App = () => {
       setIsFetching(false);
       setStatus({
         status: "error",
-        message: "No data retrieved. Try different frequency or station.",
+        message: "No data retrieved. Change frequency or station.",
         icon: <WarningIcon/>
       });
     }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -237,7 +237,7 @@ export const App = () => {
       setIsFetching(false);
       setStatus({
         status: "error",
-        message: "No data retrieved",
+        message: "No data retrieved. Try different frequency or station.",
         icon: <WarningIcon/>
       });
     }


### PR DESCRIPTION
This is a second PR (in addition to #74 ) that partially addresses issues described in PT-187533021 and PT-187569691

Updated and added some status update messages and logic:
- Active stations with no data: Prompt user to try different frequency or nearby station.
- Station selected without date range: Remind user to include date range.
- User selects time period before station was active: Show "not active during date range" warning.

Demo: https://codap.concord.org/releases/latest/static/dg/en/cert/index.html?di=https://models-resources.concord.org/noaa-codap-plugin/branch/station-message